### PR TITLE
unloads pandas if version is 0.19 or newer due to depreciated Panel4D

### DIFF
--- a/sims/sims.py
+++ b/sims/sims.py
@@ -18,9 +18,14 @@ import tarfile
 from struct import unpack
 import numpy as np
 
-# Return data in pandas 4D frame, if available, numpy array otherwise
+# Return data in pandas 4D frame, if available and pandas version supports
+# (Panel4d was depreciated in 0.19.0), numpy array otherwise
 try:
     import pandas as pd
+    # Get version as string ('X.XX.X') and split into integers
+    pandas_version = [int(v) for v in pd.__version__.split('.')]
+    if pandas_version[0] > 0 or pandas_version[1] > 18:
+        pd = None
 except ImportError:
     pd = None
 


### PR DESCRIPTION
The `Panel4D` data structure was depreciated in pandas 0.19 ([release notes](https://pandas.pydata.org/pandas-docs/stable/release.html#pandas-0-19-0)), causing errors if reading a sims file with a newer version of pandas.

This adds a check for pandas version, and unloads the module if the version is 0.19 or newer.